### PR TITLE
设置 iOS 中 Banner 广告轮播时间

### DIFF
--- a/ios/Classes/bannerad/BannerAdView.swift
+++ b/ios/Classes/bannerad/BannerAdView.swift
@@ -45,7 +45,7 @@ public class BannerAdView : NSObject,FlutterPlatformView{
         let viewWidth:CGFloat = CGFloat(self.expressViewWidth!)
         let viewHeigh:CGFloat = CGFloat(self.expressViewHeight!)
         let size = CGSize(width: viewWidth, height: viewHeigh)
-        let bannerAdView = BUNativeExpressBannerView.init(slotID: self.mCodeId!, rootViewController: MyUtils.getVC(), adSize: size, isSupportDeepLink: self.supportDeepLink!)
+        let bannerAdView = BUNativeExpressBannerView.init(slotID: self.mCodeId!, rootViewController: MyUtils.getVC(), adSize: size, isSupportDeepLink: self.supportDeepLink!, interval: Int(self.expressTime!))
         bannerAdView.delegate = self
         self.container = bannerAdView
         bannerAdView.loadAdData()


### PR DESCRIPTION
在 iOS 中没有设置 Banner 广告的轮播间隔参数，以至于配置了轮播时间但是没有轮播效果。