### PR TITLE
增加新插屏丢失的回调

### DIFF
--- a/lib/flutter_unionad_stream.dart
+++ b/lib/flutter_unionad_stream.dart
@@ -77,6 +77,12 @@ class FlutterUnionadStream {
             case OnAdMethod.onClick:
               fullScreenVideoAdInteractionCallBack?.onClick!();
               break;
+            case OnAdMethod.onSkip:
+              fullScreenVideoAdInteractionCallBack?.onSkip!();
+              break;
+            case OnAdMethod.onFinish:
+              fullScreenVideoAdInteractionCallBack?.onFinish!();
+              break;
             case OnAdMethod.onReady:
               fullScreenVideoAdInteractionCallBack?.onReady!();
               break;


### PR DESCRIPTION
**点击跳过的回调** 和 **视频播放完毕的回调** 在 iOS 和 Android 端已经发送，但是并没有在 dart 端处理。