### PR TITLE
优化 splash 加载时黑色闪屏

### DIFF
--- a/example/lib/drawfeed_page.dart
+++ b/example/lib/drawfeed_page.dart
@@ -12,6 +12,8 @@ class DrawFeedPage extends StatefulWidget {
 }
 
 class _DrawFeedPageState extends State<DrawFeedPage> {
+  bool _offstage = true;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -27,20 +29,23 @@ class _DrawFeedPageState extends State<DrawFeedPage> {
         childrenDelegate: SliverChildBuilderDelegate(
           (context, index) {
             return Center(
-              child: FlutterUnionad.drawFeedAdView(
-                androidCodeId: "945426252",
-                // Android draw视屏广告id 必填
-                iosCodeId: "945426252",
-                //ios draw视屏广告id 必填
-                supportDeepLink: true,
-                //是否支持 DeepLink 选填
-                expressViewWidth: 600.5,
-                // 期望view 宽度 dp 必填
-                expressViewHeight: 800.5,
-                //期望view高度 dp 必填
-                callBack: FlutterUnionadDrawFeedCallBack(
+              child: Offstage(
+                offstage: _offstage,
+                child: FlutterUnionad.drawFeedAdView(
+                  androidCodeId: "945426252",
+                  // Android draw视屏广告id 必填
+                  iosCodeId: "945426252",
+                  //ios draw视屏广告id 必填
+                  supportDeepLink: true,
+                  //是否支持 DeepLink 选填
+                  expressViewWidth: 600.5,
+                  // 期望view 宽度 dp 必填
+                  expressViewHeight: 800.5,
+                  //期望view高度 dp 必填
+                  callBack: FlutterUnionadDrawFeedCallBack(
                     onShow: () {
                       print("draw广告显示");
+                      setState(() => _offstage = false);
                     },
                     onFail: (error) {
                       print("draw广告加载失败 $error");
@@ -59,7 +64,9 @@ class _DrawFeedPageState extends State<DrawFeedPage> {
                     },
                     onVideoStop: () {
                       print("draw视频结束");
-                    }),
+                    },
+                  ),
+                ),
               ),
             );
           },

--- a/example/lib/splash_page.dart
+++ b/example/lib/splash_page.dart
@@ -12,6 +12,8 @@ class SplashPage extends StatefulWidget {
 }
 
 class _SplashPageState extends State<SplashPage> {
+  bool _offstage = true;
+
   @override
   void initState() {
     super.initState();
@@ -21,41 +23,45 @@ class _SplashPageState extends State<SplashPage> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        FlutterUnionad.splashAdView(
-          //是否使用个性化模版  设定widget宽高
-          mIsExpress: true,
-          //android 开屏广告广告id 必填
-          androidCodeId: "887367774",
-          //ios 开屏广告广告id 必填
-          iosCodeId: "887367774",
-          //是否支持 DeepLink 选填
-          supportDeepLink: true,
-          // 期望view 宽度 dp 选填 mIsExpress=true必填
-          expressViewWidth: 750,
-          //期望view高度 dp 选填 mIsExpress=true必填
-          expressViewHeight: 800,
-          callBack: FlutterUnionadSplashCallBack(
-            onShow: () {
-              print("开屏广告显示");
-            },
-            onClick: () {
-              print("开屏广告点击");
-              Navigator.pop(context);
-            },
-            onFail: (error) {
-              print("开屏广告失败 $error");
-            },
-            onFinish: () {
-              print("开屏广告倒计时结束");
-              Navigator.pop(context);
-            },
-            onSkip: () {
-              print("开屏广告跳过");
-              Navigator.pop(context);
-            },
-            onTimeOut: () {
-              print("开屏广告超时");
-            },
+        Offstage(
+          offstage: _offstage,
+          child: FlutterUnionad.splashAdView(
+            //是否使用个性化模版  设定widget宽高
+            mIsExpress: true,
+            //android 开屏广告广告id 必填
+            androidCodeId: "887367774",
+            //ios 开屏广告广告id 必填
+            iosCodeId: "887367774",
+            //是否支持 DeepLink 选填
+            supportDeepLink: true,
+            // 期望view 宽度 dp 选填 mIsExpress=true必填
+            expressViewWidth: 750,
+            //期望view高度 dp 选填 mIsExpress=true必填
+            expressViewHeight: 800,
+            callBack: FlutterUnionadSplashCallBack(
+              onShow: () {
+                print("开屏广告显示");
+                setState(() => _offstage = false);
+              },
+              onClick: () {
+                print("开屏广告点击");
+                Navigator.pop(context);
+              },
+              onFail: (error) {
+                print("开屏广告失败 $error");
+              },
+              onFinish: () {
+                print("开屏广告倒计时结束");
+                Navigator.pop(context);
+              },
+              onSkip: () {
+                print("开屏广告跳过");
+                Navigator.pop(context);
+              },
+              onTimeOut: () {
+                print("开屏广告超时");
+              },
+            ),
           ),
         ),
         Expanded(


### PR DESCRIPTION
开屏和 draw 视频广告两个页面，使用 Offstage 组件包裹广告，避免出现黑色闪屏。

banner 和信息流使用同样的方式没有解决，所以本次 pull 不包含这两个。