### PR TITLE
信息流广告，添加iosIsUserInteractionEnabled属性，用于控制原生交互事件

### DIFF
--- a/ios/Classes/nativead/NativeAdView.swift
+++ b/ios/Classes/nativead/NativeAdView.swift
@@ -38,6 +38,16 @@ public class NativeAdView : NSObject,FlutterPlatformView{
         self.nativeExpressAdManager = BUNativeExpressAdManager()
         super.init()
         self.channel = FlutterMethodChannel.init(name: FlutterUnionadConfig.view.nativeAdView + "_" + String(id), binaryMessenger: binaryMessenger)
+        self.channel?.setMethodCallHandler({[weak self] call, result in
+            if call.method == "iosIsUserInteractionEnabled" {
+                if let argument = call.arguments as? [String:Any], let iosIsUserInteractionEnabled = argument["iosIsUserInteractionEnabled"] as? Bool {
+                    self?.container.isUserInteractionEnabled = iosIsUserInteractionEnabled
+                }
+                result(nil)
+                return
+            }
+            result(FlutterMethodNotImplemented)
+        })
         self.loadNativeExpressAd()
         LogUtil.logInstance.printLog(message: id)
     }

--- a/lib/flutter_unionad.dart
+++ b/lib/flutter_unionad.dart
@@ -213,6 +213,7 @@ class FlutterUnionad {
       required double expressViewHeight,
       required int expressNum,
       int? downloadType,
+      bool? iosIsUserInteractionEnabled,
       FlutterUnionadNativeCallBack? callBack}) {
     return NativeAdView(
       mIsExpress: mIsExpress ?? false,
@@ -224,6 +225,7 @@ class FlutterUnionad {
       expressNum: expressNum,
       downloadType:
           downloadType ?? FlutterUnionadDownLoadType.DOWNLOAD_TYPE_POPUP,
+      iosIsUserInteractionEnabled: iosIsUserInteractionEnabled,
       callBack: callBack,
     );
   }


### PR DESCRIPTION
解决广告上层出现弹窗时，底层广告仍响应交互的问题

[iOS在广告页上显示弹窗，点击弹窗，底层的广告会响应点击事件。 #42](https://github.com/gstory0404/flutter_unionad/issues/42)