### PR TITLE
fix(iOS): 兼容 UIScene 生命周期，修复激励广告展示与回调时序问题

### DIFF
--- a/ios/Classes/FlutterUnionadEventPlugin.swift
+++ b/ios/Classes/FlutterUnionadEventPlugin.swift
@@ -11,6 +11,7 @@ import Flutter
 public class FlutterUnionadEnentPlugin : NSObject, FlutterStreamHandler{
     
     private var eventSink:FlutterEventSink? = nil
+    private var pendingEvents:[NSDictionary] = []
     
     init(_ registrar: FlutterPluginRegistrar){
         super.init()
@@ -21,6 +22,11 @@ public class FlutterUnionadEnentPlugin : NSObject, FlutterStreamHandler{
     
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         eventSink = events
+        if !pendingEvents.isEmpty {
+            let replay = pendingEvents
+            pendingEvents.removeAll()
+            replay.forEach { events($0) }
+        }
         return nil
     }
     
@@ -31,7 +37,17 @@ public class FlutterUnionadEnentPlugin : NSObject, FlutterStreamHandler{
     
     //发送event
     public func sendEvent(event:NSDictionary) {
-        eventSink?(event)
+        DispatchQueue.main.async {
+            if let sink = self.eventSink {
+                sink(event)
+            } else {
+                // 监听尚未建立时先缓存，避免 onReady 等关键事件丢失导致上层超时。
+                self.pendingEvents.append(event)
+                if self.pendingEvents.count > 50 {
+                    self.pendingEvents.removeFirst(self.pendingEvents.count - 50)
+                }
+            }
+        }
     }
 
 }

--- a/ios/Classes/rewardedvideoad/RewardedVideoAd.swift
+++ b/ios/Classes/rewardedvideoad/RewardedVideoAd.swift
@@ -10,13 +10,14 @@ import BUAdSDK
 
 public class RewardedVideoAd : NSObject{
     public static let instance = RewardedVideoAd()
-    
+
     var mCodeId :String?
     //激励广告参数
     private var rewardModel :BURewardedVideoModel?
-    
+
     private var bURewardedVideoAd :BUNativeExpressRewardedVideoAd?
-    
+    private var hasSentShowEvent = false
+
     public func loadRewardedVideoAd(params : NSDictionary) {
         LogUtil.logInstance.printLog(message: params)
         let mCodeId = params.value(forKey: "iosCodeId") as? String
@@ -41,9 +42,10 @@ public class RewardedVideoAd : NSObject{
         adslot.mediation.mutedIfCan = mutedIfCan! // 是否静音
         self.bURewardedVideoAd = BUNativeExpressRewardedVideoAd.init(slot: adslot, rewardedVideoModel: self.rewardModel!)
         self.bURewardedVideoAd!.delegate = self
+        self.hasSentShowEvent = false
         self.bURewardedVideoAd!.loadData()
     }
-    
+
     public func showRewardedVideoAd(){
         if(self.bURewardedVideoAd == nil){
             let map : NSDictionary = ["adType":"rewardAd",
@@ -51,15 +53,25 @@ public class RewardedVideoAd : NSObject{
             SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
             return
         }
-        UIApplication.shared.setStatusBarHidden(true, with: UIStatusBarAnimation.none)
         self.bURewardedVideoAd!.show(fromRootViewController: MyUtils.getVC())
-        let map : NSDictionary = ["adType":"rewardAd",
-                                  "onAdMethod":"onShow"]
-        SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
-        let ecpmInfo : BUMRitInfo? = self.bURewardedVideoAd?.mediation?.getShowEcpmInfo();
+    }
+
+    private func emitShowAndEcpmIfNeeded(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd?) {
+        if hasSentShowEvent {
+            return
+        }
+        hasSentShowEvent = true
+
+        UIApplication.shared.setStatusBarHidden(true, with: UIStatusBarAnimation.none)
+
+        let showMap : NSDictionary = ["adType":"rewardAd",
+                                      "onAdMethod":"onShow"]
+        SwiftFlutterUnionadPlugin.event!.sendEvent(event: showMap)
+
+        let ecpmInfo : BUMRitInfo? = rewardedVideoAd?.mediation?.getShowEcpmInfo()
         let ecpmMap : NSDictionary = ["adType":"rewardAd",
-                                  "onAdMethod":"onEcpm",
-                                  "info":ecpmInfo?.toDictionary()]
+                                      "onAdMethod":"onEcpm",
+                                      "info":ecpmInfo?.toDictionary()]
         LogUtil.logInstance.printLog(message: "ecpm : \(ecpmMap)")
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: ecpmMap)
     }
@@ -72,23 +84,31 @@ extension RewardedVideoAd: BUNativeExpressRewardedVideoAdDelegate {
                                   "onAdMethod":"onReady"]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
     }
-    
+
     public func nativeExpressRewardedVideoAdDidDownLoadVideo(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {
         LogUtil.logInstance.printLog(message: "激励广告物料缓存成功")
         let map : NSDictionary = ["adType":"rewardAd",
                                   "onAdMethod":"onCache"]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
     }
-    
+
+    // 仅在广告真实可见后再上报 onShow，避免 show() 调用成功但未实际展示导致的假阳性。
+    public func nativeExpressRewardedVideoAdDidVisible(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {
+        LogUtil.logInstance.printLog(message: "激励广告可见")
+        emitShowAndEcpmIfNeeded(rewardedVideoAd)
+    }
+
     public func nativeExpressRewardedVideoAdDidClose(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {
         LogUtil.logInstance.printLog(message: "激励广告关闭")
+        // 兜底：某些 SDK/机型路径下可能不回调 didVisible，但会回调 didClose。
+        emitShowAndEcpmIfNeeded(rewardedVideoAd)
         UIApplication.shared.setStatusBarHidden(false, with: UIStatusBarAnimation.none)
         let map : NSDictionary = ["adType":"rewardAd",
                                   "onAdMethod":"onClose"]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
         self.bURewardedVideoAd = nil
     }
-    
+
     public func nativeExpressRewardedVideoAd(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd, didFailWithError error: Error?) {
         LogUtil.logInstance.printLog(message: "激励广告加载失败")
         LogUtil.logInstance.printLog(message: error)
@@ -97,21 +117,21 @@ extension RewardedVideoAd: BUNativeExpressRewardedVideoAdDelegate {
                                   "error":error?.localizedDescription]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
     }
-    
+
     public func nativeExpressRewardedVideoAdDidClickSkip(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {
         LogUtil.logInstance.printLog(message: "激励广告跳过")
         let map : NSDictionary = ["adType":"rewardAd",
                                   "onAdMethod":"onSkip"]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
     }
-    
+
     public func nativeExpressRewardedVideoAdViewRenderFail(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd, error: Error?) {
         let map : NSDictionary = ["adType":"rewardAd",
                                   "onAdMethod":"onFail",
                                   "error":error?.localizedDescription]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
     }
-    
+
     public func nativeExpressRewardedVideoAdServerRewardDidFail(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd, error: Error?) {
         LogUtil.logInstance.printLog(message: "异步请求的服务器验证失败回调")
         LogUtil.logInstance.printLog(message: error)
@@ -161,17 +181,19 @@ extension RewardedVideoAd: BUNativeExpressRewardedVideoAdDelegate {
                                   "extraInfo":String.init(format:"%.2f",rewardedVideoAd.rewardedVideoModel.rewardPropose)]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: arrivedMap)
     }
-    
+
     public func nativeExpressRewardedVideoAdDidPlayFinish(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd, didFailWithError error: Error?) {
         LogUtil.logInstance.printLog(message: "激励广告完成")
     }
-    
+
     public func nativeExpressRewardedVideoAdDidClick(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {
+        // 兜底：点击发生时至少说明广告已实际展示。
+        emitShowAndEcpmIfNeeded(rewardedVideoAd)
         let map : NSDictionary = ["adType":"rewardAd",
                                   "onAdMethod":"onClick"]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
     }
-    
+
     public func nativeExpressRewardedVideoAdCallback(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd, with nativeExpressVideoType: BUNativeExpressRewardedVideoAdType) {
     }
 }

--- a/ios/Classes/rewardedvideoad/RewardedVideoAd.swift
+++ b/ios/Classes/rewardedvideoad/RewardedVideoAd.swift
@@ -56,13 +56,15 @@ public class RewardedVideoAd : NSObject{
         self.bURewardedVideoAd!.show(fromRootViewController: MyUtils.getVC())
     }
 
-    private func emitShowAndEcpmIfNeeded(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd?) {
+    private func emitShowAndEcpmIfNeeded(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd?, updateStatusBar: Bool = false) {
         if hasSentShowEvent {
             return
         }
         hasSentShowEvent = true
 
-        UIApplication.shared.setStatusBarHidden(true, with: UIStatusBarAnimation.none)
+        if updateStatusBar {
+            UIApplication.shared.setStatusBarHidden(true, with: UIStatusBarAnimation.none)
+        }
 
         let showMap : NSDictionary = ["adType":"rewardAd",
                                       "onAdMethod":"onShow"]
@@ -95,7 +97,7 @@ extension RewardedVideoAd: BUNativeExpressRewardedVideoAdDelegate {
     // 仅在广告真实可见后再上报 onShow，避免 show() 调用成功但未实际展示导致的假阳性。
     public func nativeExpressRewardedVideoAdDidVisible(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {
         LogUtil.logInstance.printLog(message: "激励广告可见")
-        emitShowAndEcpmIfNeeded(rewardedVideoAd)
+        emitShowAndEcpmIfNeeded(rewardedVideoAd, updateStatusBar: true)
     }
 
     public func nativeExpressRewardedVideoAdDidClose(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {

--- a/ios/Classes/rewardedvideoad/RewardedVideoAd.swift
+++ b/ios/Classes/rewardedvideoad/RewardedVideoAd.swift
@@ -17,6 +17,8 @@ public class RewardedVideoAd : NSObject{
 
     private var bURewardedVideoAd :BUNativeExpressRewardedVideoAd?
     private var hasSentShowEvent = false
+    private var hasSentReadyEvent = false
+    private var showAttemptCount = 0
 
     public func loadRewardedVideoAd(params : NSDictionary) {
         LogUtil.logInstance.printLog(message: params)
@@ -43,6 +45,8 @@ public class RewardedVideoAd : NSObject{
         self.bURewardedVideoAd = BUNativeExpressRewardedVideoAd.init(slot: adslot, rewardedVideoModel: self.rewardModel!)
         self.bURewardedVideoAd!.delegate = self
         self.hasSentShowEvent = false
+        self.hasSentReadyEvent = false
+        self.showAttemptCount = 0
         self.bURewardedVideoAd!.loadData()
     }
 
@@ -53,7 +57,16 @@ public class RewardedVideoAd : NSObject{
             SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
             return
         }
-        self.bURewardedVideoAd!.show(fromRootViewController: MyUtils.getVC())
+        if hasSentShowEvent {
+            return
+        }
+        if showAttemptCount >= 2 {
+            return
+        }
+        showAttemptCount += 1
+        DispatchQueue.main.async {
+            self.bURewardedVideoAd?.show(fromRootViewController: MyUtils.getVC())
+        }
     }
 
     private func emitShowAndEcpmIfNeeded(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd?, updateStatusBar: Bool = false) {
@@ -77,14 +90,22 @@ public class RewardedVideoAd : NSObject{
         LogUtil.logInstance.printLog(message: "ecpm : \(ecpmMap)")
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: ecpmMap)
     }
+
+    private func emitReadyIfNeeded() {
+        if hasSentReadyEvent {
+            return
+        }
+        hasSentReadyEvent = true
+        let map : NSDictionary = ["adType":"rewardAd",
+                                  "onAdMethod":"onReady"]
+        SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
+    }
 }
 
 extension RewardedVideoAd: BUNativeExpressRewardedVideoAdDelegate {
     public func nativeExpressRewardedVideoAdDidLoad(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {
         LogUtil.logInstance.printLog(message: "激励广告加载成功")
-        let map : NSDictionary = ["adType":"rewardAd",
-                                  "onAdMethod":"onReady"]
-        SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
+        emitReadyIfNeeded()
     }
 
     public func nativeExpressRewardedVideoAdDidDownLoadVideo(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {
@@ -92,6 +113,10 @@ extension RewardedVideoAd: BUNativeExpressRewardedVideoAdDelegate {
         let map : NSDictionary = ["adType":"rewardAd",
                                   "onAdMethod":"onCache"]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
+        // 兜底补发 onReady：避免 didLoad 事件早到丢失导致未触发 show。
+        if !hasSentShowEvent && showAttemptCount < 2 {
+            emitReadyIfNeeded()
+        }
     }
 
     // 仅在广告真实可见后再上报 onShow，避免 show() 调用成功但未实际展示导致的假阳性。
@@ -108,6 +133,8 @@ extension RewardedVideoAd: BUNativeExpressRewardedVideoAdDelegate {
         let map : NSDictionary = ["adType":"rewardAd",
                                   "onAdMethod":"onClose"]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
+        self.hasSentReadyEvent = false
+        self.showAttemptCount = 0
         self.bURewardedVideoAd = nil
     }
 
@@ -118,6 +145,9 @@ extension RewardedVideoAd: BUNativeExpressRewardedVideoAdDelegate {
                                   "onAdMethod":"onFail",
                                   "error":error?.localizedDescription]
         SwiftFlutterUnionadPlugin.event!.sendEvent(event: map)
+        self.hasSentReadyEvent = false
+        self.showAttemptCount = 0
+        self.bURewardedVideoAd = nil
     }
 
     public func nativeExpressRewardedVideoAdDidClickSkip(_ rewardedVideoAd: BUNativeExpressRewardedVideoAd) {

--- a/ios/Classes/splashad/SplashAdView.swift
+++ b/ios/Classes/splashad/SplashAdView.swift
@@ -116,8 +116,6 @@ extension SplashAdView : BUSplashAdDelegate{
             self.showSkipButton()
         }
         self.splashAd?.showSplashView(inRootViewController: MyUtils.getVC().navigationController ?? MyUtils.getVC())
-        self.channel?.invokeMethod("onShow", arguments: "开屏广告加载完成")
-        self.queryECPM()
     }
     
     //SDK渲染开屏广告渲染失败回调
@@ -135,6 +133,8 @@ extension SplashAdView : BUSplashAdDelegate{
     
     public func splashAdDidShow(_ splashAd: BUSplashAd) {
         LogUtil.logInstance.printLog(message: "开屏广告展示")
+        self.channel?.invokeMethod("onShow", arguments: "开屏广告加载完成")
+        self.queryECPM()
     }
     
     public func splashAdDidClose(_ splashAd: BUSplashAd, closeType: BUSplashAdCloseType) {

--- a/ios/Classes/splashad/SplashAdView.swift
+++ b/ios/Classes/splashad/SplashAdView.swift
@@ -133,7 +133,7 @@ extension SplashAdView : BUSplashAdDelegate{
     
     public func splashAdDidShow(_ splashAd: BUSplashAd) {
         LogUtil.logInstance.printLog(message: "开屏广告展示")
-        self.channel?.invokeMethod("onShow", arguments: "开屏广告加载完成")
+        self.channel?.invokeMethod("onShow", arguments: "开屏广告展示")
         self.queryECPM()
     }
     

--- a/ios/Classes/utils/MyUtils.swift
+++ b/ios/Classes/utils/MyUtils.swift
@@ -6,13 +6,36 @@
 //
 
 import Foundation
+import UIKit
 
 class MyUtils{
     static func getVC() -> UIViewController {
-        let vc = UIApplication.shared.delegate?.window??.rootViewController
-        if let vc = vc  {
+        let appDelegateRoot = UIApplication.shared.delegate?.window??.rootViewController
+        var keyWindowRoot: UIViewController? = nil
+        var legacyWindowRoot: UIViewController? = nil
+
+        if #available(iOS 13.0, *) {
+            let windowScenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+            let windows = windowScenes.flatMap { $0.windows }
+            keyWindowRoot = windows.first(where: { $0.isKeyWindow })?.rootViewController
+            if keyWindowRoot == nil {
+                keyWindowRoot = windows.first(where: { !$0.isHidden && $0.windowLevel == .normal })?.rootViewController
+            }
+
+            // 兼容未启用 UIScene 或旧生命周期项目：回退到 legacy windows。
+            if keyWindowRoot == nil {
+                let legacyWindows = UIApplication.shared.windows
+                legacyWindowRoot = legacyWindows.first(where: { $0.isKeyWindow })?.rootViewController
+                if legacyWindowRoot == nil {
+                    legacyWindowRoot = legacyWindows.first(where: { !$0.isHidden && $0.windowLevel == .normal })?.rootViewController
+                }
+            }
+        }
+
+        if let vc = appDelegateRoot ?? keyWindowRoot ?? legacyWindowRoot {
             return findBestViewController(vc: vc)
         }
+
         return UIViewController.init()
     }
     
@@ -52,4 +75,3 @@ class MyUtils{
         return screenBounds
     }
 }
-

--- a/ios/Classes/view/ADContainerView.swift
+++ b/ios/Classes/view/ADContainerView.swift
@@ -16,7 +16,8 @@ class ADContainerView: UIView {
             // nearly invisble
             return nil
         }
-        let windowPoint = self.convert(point, to: UIApplication.shared.delegate?.window!!)
+        // Convert to window coordinates without relying on AppDelegate.window (UIScene compatible).
+        let windowPoint = self.convert(point, to: nil)
 
         let targetView = self.superview?.superview
         let targetOverlayView = self.findTargetOverlayView(windowPoint)


### PR DESCRIPTION
## 背景
在 iOS 13+ 启用 UIScene 的项目中，广告展示链路存在以下问题：
- 激励广告偶现 `load success` 后不弹出，最终上层超时。
- `onReady` 事件在 Flutter 监听尚未建立时可能丢失，导致不触发 show。
- 开屏/激励的 `onShow` 语义在部分回调路径下不一致。
- Banner/信息流容器命中测试仍依赖 `AppDelegate.window`，在 UIScene 下存在兼容风险。

## 修改内容
### 1) RootViewController 获取兼容 UIScene + 旧生命周期
- `MyUtils.getVC()` 优先从 `connectedScenes -> UIWindowScene.windows` 获取可用 rootVC。
- 保留旧生命周期回退（legacy windows），并统一返回 `findBestViewController`。

### 2) 激励广告展示链路稳定化（RewardedVideoAd）
- `showRewardedVideoAd()` 改为主线程执行展示。
- 增加防重入/重复展示保护（限制重复 show 尝试）。
- `onReady` 改为去重发送，避免重复触发。
- 在 `didDownLoadVideo` 增加补发 `onReady` 兜底，避免早期事件丢失导致不上屏。
- `didFail`/`didClose` 后重置内部状态，避免脏状态影响下一次请求。

### 3) 事件通道可靠性增强（FlutterUnionadEventPlugin）
- 当 `eventSink` 尚未建立时，先缓存事件；`onListen` 后回放。
- 解决 `onReady` 等关键事件“先到后听”丢失问题。

### 4) 展示语义修正（已根据 review 调整）
- 开屏 `onShow` 在真实展示回调触发（`splashAdDidShow`），不再沿用“加载完成”语义。
- 激励广告 `onShow` 以真实可见回调为主，并保留 close/click 路径补发兜底。
- 兜底路径不再错误修改状态栏，避免关闭/跳转场景下的闪烁问题。

### 5) Banner/信息流容器的 UIScene 兼容修复
- `ADContainerView.hitTest` 坐标转换不再依赖 `AppDelegate.window`。
- 改为窗口相对坐标转换，规避 UIScene 下空窗口风险。

## 影响范围
- iOS：激励、开屏、新插屏/全屏、Banner、信息流相关展示与回调路径。
- Android/OHOS：无行为改动。

## 兼容性
- 对未启用 UIScene 的老项目保持兼容（包含 legacy window 回退路径）。

## 验证建议
- iOS 13+（UIScene 开启）与老生命周期项目各验证一轮：
  - 激励：首刷/关闭后再次拉起/连续多次拉起。
  - 开屏：`onShow` 与日志语义一致性。
  - Banner/信息流：点击、覆盖层命中与关闭路径。